### PR TITLE
Swagger support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,4 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
+max_line_length = 80

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 # Ignore ES5 source directory on github.
 # http://mammal.io/articles/using-es6-today/#getting-started
 lib
+
+*.sublime-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 lib
 
 *.sublime-workspace
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ npm-debug.log
 *.sublime-*
 test
 karma.conf.js
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "iojs"
+  - "5.0.0"
+  - "4.2.2"
   - "0.12"
   - "0.10"
 before_install:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Deckard Cain library identifies (media) type of API description files.
 
 - [API Blueprint](https://apiblueprint.org/) - `text/vnd.apiblueprint`
 - Legacy Apiary Blueprint (predecessor of API Blueprint) - `text/vnd.legacyblueprint`
+- Swagger - `application/swagger+json` (according to [swagger-api/swagger-spec#110](https://github.com/swagger-api/swagger-spec/issues/110)) and `application/swagger+yaml`
 
 ## Install
 

--- a/deckardcain.sublime-project
+++ b/deckardcain.sublime-project
@@ -1,0 +1,18 @@
+{
+  "folders": [
+    {
+      "name": "deckardcain",
+      "path": "/",
+      "folder_exclude_patterns": [
+        "node_modules",
+        "build",
+        "tmp"
+      ]
+    }
+  ],
+  "settings": {
+    "tab_size": 2,
+    "translate_tabs_to_spaces": true,
+    "rulers": [79]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-eslint": "^4.0.10",
     "babelify": "^6.2.0",
     "chai": "^3.2.0",
+    "dedent": "^0.6.0",
     "eslint": "^1.2.1",
     "karma": "^0.13.3",
     "karma-browserify": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.0.4",
     "mocha": "^2.2.1"
+  },
+  "dependencies": {
+    "js-yaml": "^3.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "babelify": "^6.2.0",
     "chai": "^3.2.0",
     "eslint": "^1.2.1",
-    "eslint-config-airbnb": "0.0.8",
     "karma": "^0.13.3",
     "karma-browserify": "^4.2.1",
     "karma-chai": "^0.1.0",
     "karma-firefox-launcher": "^0.1.6",
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.0.4",
+    "eslint-config-airbnb": "^1.0.0",
     "mocha": "^2.2.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deckardcain",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Identifies (media) type of API description files",
   "main": "lib/deckardcain",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,5 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.0.4",
     "mocha": "^2.2.1"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/deckardcain.es6
+++ b/src/deckardcain.es6
@@ -47,7 +47,7 @@ function identify(source) {
     // turn it into a rather smart casual leather armor?
 
     return null;
-  } catch(e) {
+  } catch (jsonException) {
     // Well ok, it's not a JSON...Maybe we're dealing with YAML file?
     try {
       const yaml = YAML.safeLoad(source);
@@ -56,11 +56,10 @@ function identify(source) {
         // Indeed, we are dealing with Swagger file!
         return 'application/swagger+yaml';
       }
-    } catch (e) {
+    } catch (yamlException) {
       // To be honest, I have no idea.
       return null;
     }
-
   }
 }
 

--- a/src/deckardcain.es6
+++ b/src/deckardcain.es6
@@ -13,27 +13,45 @@ const LEGACY_BLUEPRINT_TITLE = /\-{3} ([^\n\r]+ )?\-{3}([\n\r]{1,2}|$)/;
 function identify(source) {
   // Stay awhile and listen!
 
-  if (source.match(API_BLUEPRINT_HEADER)) {
-    // I spotted 'FORMAT: 1A' header. This is a clear clue that
-    // the file is API Blueprint.
-    return 'text/vnd.apiblueprint';
-  }
+  try {
+    const json = JSON.parse(source);
 
-  if (source.match(LEGACY_BLUEPRINT_TITLE)) {
-    // I spotted '--- Sample Title ---' title. This looks like
-    // we are dealing with the legacy Apiary Blueprint.
-    return 'text/vnd.legacyblueprint';
-  }
+    // It looks like the source is a valid JSON file. I suspect it to
+    // be a Swagger file.
+    if (json.swagger) {
+      // Indeed, we are dealing with Swagger file!
+      return 'application/swagger+json';
+    }
 
-  if (source.match(API_BLUEPRINT_RESPONSE)) {
-    // I can not see the '--- Sample Title ---' and at the same time
-    // there is something like '+ Response 200' in the document, which is
-    // pretty distinctive for API Blueprint.
-    return 'text/vnd.apiblueprint';
-  }
+    // Nothing I could identify. Maybe Horadric Cube could magically
+    // turn it into a rather smart casual leather armor?
+    return null;
+  } catch(e) {
+    // Oh! It almost blew up! I should be more careful. I'll better
+    // treat the item as a plain text file.
 
-  // I do not know. Very strange item!
-  return null;
+    if (source.match(API_BLUEPRINT_HEADER)) {
+      // I spotted 'FORMAT: 1A' header, which gives us a clear clue that
+      // the file is API Blueprint.
+      return 'text/vnd.apiblueprint';
+    }
+
+    if (source.match(LEGACY_BLUEPRINT_TITLE)) {
+      // I spotted '--- Sample Title ---' title. This looks like
+      // we are dealing with the legacy Apiary Blueprint.
+      return 'text/vnd.legacyblueprint';
+    }
+
+    if (source.match(API_BLUEPRINT_RESPONSE)) {
+      // I can not see the '--- Sample Title ---' and at the same time
+      // there is something like '+ Response 200' in the document, which is
+      // pretty distinctive for API Blueprint.
+      return 'text/vnd.apiblueprint';
+    }
+
+    // I do not know. Very strange item!
+    return null;
+  }
 }
 
 

--- a/src/deckardcain.es6
+++ b/src/deckardcain.es6
@@ -13,6 +13,25 @@ const LEGACY_BLUEPRINT_TITLE = /\-{3} ([^\n\r]+ )?\-{3}([\n\r]{1,2}|$)/;
 function identify(source) {
   // Stay awhile and listen!
 
+  if (source.match(API_BLUEPRINT_HEADER)) {
+    // I spotted 'FORMAT: 1A' header, which gives us a clear clue that
+    // the file is API Blueprint.
+    return 'text/vnd.apiblueprint';
+  }
+
+  if (source.match(LEGACY_BLUEPRINT_TITLE)) {
+    // I spotted '--- Sample Title ---' title. This looks like
+    // we are dealing with the legacy Apiary Blueprint.
+    return 'text/vnd.legacyblueprint';
+  }
+
+  if (source.match(API_BLUEPRINT_RESPONSE)) {
+    // I can not see the '--- Sample Title ---' and at the same time
+    // there is something like '+ Response 200' in the document, which is
+    // pretty distinctive for API Blueprint.
+    return 'text/vnd.apiblueprint';
+  }
+
   try {
     const json = JSON.parse(source);
 
@@ -27,29 +46,6 @@ function identify(source) {
     // turn it into a rather smart casual leather armor?
     return null;
   } catch(e) {
-    // Oh! It almost blew up! I should be more careful. I'll better
-    // treat the item as a plain text file.
-
-    if (source.match(API_BLUEPRINT_HEADER)) {
-      // I spotted 'FORMAT: 1A' header, which gives us a clear clue that
-      // the file is API Blueprint.
-      return 'text/vnd.apiblueprint';
-    }
-
-    if (source.match(LEGACY_BLUEPRINT_TITLE)) {
-      // I spotted '--- Sample Title ---' title. This looks like
-      // we are dealing with the legacy Apiary Blueprint.
-      return 'text/vnd.legacyblueprint';
-    }
-
-    if (source.match(API_BLUEPRINT_RESPONSE)) {
-      // I can not see the '--- Sample Title ---' and at the same time
-      // there is something like '+ Response 200' in the document, which is
-      // pretty distinctive for API Blueprint.
-      return 'text/vnd.apiblueprint';
-    }
-
-    // I do not know. Very strange item!
     return null;
   }
 }

--- a/src/deckardcain.es6
+++ b/src/deckardcain.es6
@@ -14,24 +14,7 @@ const LEGACY_BLUEPRINT_TITLE = /\-{3} ([^\n\r]+ )?\-{3}([\n\r]{1,2}|$)/;
 function identify(source) {
   // Stay awhile and listen!
 
-  if (source.match(API_BLUEPRINT_HEADER)) {
-    // I spotted 'FORMAT: 1A' header, which gives us a clear clue that
-    // the file is API Blueprint.
-    return 'text/vnd.apiblueprint';
-  }
-
-  if (source.match(LEGACY_BLUEPRINT_TITLE)) {
-    // I spotted '--- Sample Title ---' title. This looks like
-    // we are dealing with the legacy Apiary Blueprint.
-    return 'text/vnd.legacyblueprint';
-  }
-
-  if (source.match(API_BLUEPRINT_RESPONSE)) {
-    // I can not see the '--- Sample Title ---' and at the same time
-    // there is something like '+ Response 200' in the document, which is
-    // pretty distinctive for API Blueprint.
-    return 'text/vnd.apiblueprint';
-  }
+  let identifiedType = null;
 
   try {
     const json = JSON.parse(source);
@@ -40,13 +23,8 @@ function identify(source) {
     // be a Swagger file.
     if (json.swagger) {
       // Indeed, we are dealing with Swagger file!
-      return 'application/swagger+json';
+      identifiedType = 'application/swagger+json';
     }
-
-    // Nothing I could identify. Maybe Horadric Cube could magically
-    // turn it into a rather smart casual leather armor?
-
-    return null;
   } catch (jsonException) {
     // Well ok, it's not a JSON...Maybe we're dealing with YAML file?
     try {
@@ -54,12 +32,30 @@ function identify(source) {
 
       if (yaml.swagger) {
         // Indeed, we are dealing with Swagger file!
-        return 'application/swagger+yaml';
+        identifiedType = 'application/swagger+yaml';
       }
     } catch (yamlException) {
-      // To be honest, I have no idea.
-      return null;
+      // Well ok I am sorry, it's not a Swaggerish
     }
+  } finally {
+    if (identifiedType === null) {
+      if (source.match(API_BLUEPRINT_HEADER)) {
+        // I spotted 'FORMAT: 1A' header, which gives us a clear clue that
+        // the file is API Blueprint.
+        identifiedType = 'text/vnd.apiblueprint';
+      } else if (source.match(LEGACY_BLUEPRINT_TITLE)) {
+        // I spotted '--- Sample Title ---' title. This looks like
+        // we are dealing with the legacy Apiary Blueprint.
+        identifiedType = 'text/vnd.legacyblueprint';
+      } else if (source.match(API_BLUEPRINT_RESPONSE)) {
+        // I can not see the '--- Sample Title ---' and at the same time
+        // there is something like '+ Response 200' in the document, which is
+        // pretty distinctive for API Blueprint.
+        identifiedType = 'text/vnd.apiblueprint';
+      }
+    }
+
+    return identifiedType;
   }
 }
 

--- a/src/deckardcain.es6
+++ b/src/deckardcain.es6
@@ -1,3 +1,4 @@
+import YAML from 'js-yaml';
 
 const API_BLUEPRINT_HEADER = /^[\uFEFF]?(((VERSION:( |\t)2)|(FORMAT:( |\t)(X-)?1A))([\n\r]{1,2}|$))/i;
 const API_BLUEPRINT_RESPONSE = /\+\s+Response\s+\d{3}/i;
@@ -44,9 +45,22 @@ function identify(source) {
 
     // Nothing I could identify. Maybe Horadric Cube could magically
     // turn it into a rather smart casual leather armor?
+
     return null;
   } catch(e) {
-    return null;
+    // Well ok, it's not a JSON...Maybe we're dealing with YAML file?
+    try {
+      const yaml = YAML.safeLoad(source);
+
+      if (yaml.swagger) {
+        // Indeed, we are dealing with Swagger file!
+        return 'application/swagger+yaml';
+      }
+    } catch (e) {
+      // To be honest, I have no idea.
+      return null;
+    }
+
   }
 }
 

--- a/test/identify-test.es6
+++ b/test/identify-test.es6
@@ -1,17 +1,17 @@
-
+import dedent from 'dedent';
 import {assert} from 'chai';
 import {identify} from '../lib/deckardcain';
 
 
 describe('API Blueprint', () => {
   describe('with FORMAT header', () => {
-    const source = `
-FORMAT: 1A
+    const source = dedent`
+      FORMAT: 1A
 
-# /messages/{id}
+      # /messages/{id}
 
-## DELETE
-+ Response 204
+      ## DELETE
+      + Response 204
     `;
 
     it('is identified as API Blueprint', () => {
@@ -20,13 +20,13 @@ FORMAT: 1A
   });
 
   describe('with UTF8 BOM and FORMAT header', () => {
-    const source = `\uFEFF
-FORMAT: 1A
+    const source = dedent`\uFEFF
+      FORMAT: 1A
 
-# /messages/{id}
+      # /messages/{id}
 
-## DELETE
-+ Response 204
+      ## DELETE
+      + Response 204
     `;
 
     it('is identified as API Blueprint', () => {
@@ -35,13 +35,13 @@ FORMAT: 1A
   });
 
   describe('with \\r line breaks and arbitrary valid content', () => {
-    const source = `\r
-FORMAT: 1A\r
-\r
-# /messages/{id}\r
-\r
-## DELETE\r
-+ Response 204\r
+    const source = dedent`\r
+      FORMAT: 1A\r
+      \r
+      # /messages/{id}\r
+      \r
+      ## DELETE\r
+      + Response 204\r
     `;
 
     it('is identified as API Blueprint', () => {
@@ -50,11 +50,11 @@ FORMAT: 1A\r
   });
 
   describe('without FORMAT header but with any typical response', () => {
-    const source = `
-# /messages/{id}
+    const source = dedent`
+      # /messages/{id}
 
-## DELETE
-+ Response 204
+      ## DELETE
+      + Response 204
     `;
 
     it('is identified as API Blueprint', () => {
@@ -71,13 +71,13 @@ FORMAT: 1A\r
   });
 
   describe('without FORMAT header or any typical response', () => {
-    const source = `
-# Data Structures API
+    const source = dedent`
+      # Data Structures API
 
-## Data Structures
+      ## Data Structures
 
-### Coupon Base (object)
-+ redeem_by (number) - Date after which the coupon can no longer be redeemed
+      ### Coupon Base (object)
+      + redeem_by (number) - Date after which the coupon can no longer be redeemed
     `;
 
     it('is not identified', () => {
@@ -97,18 +97,18 @@ FORMAT: 1A\r
 
 describe('Legacy Apiary Blueprint', () => {
   describe('with arbitrary valid content', () => {
-    const source = `
-HOST: http://example.com/api-path
+    const source = dedent`
+      HOST: http://example.com/api-path
 
---- API Name ---
+      --- API Name ---
 
-All Messages
-POST /messages{?id,token,username}
-> X-Brewery-Since: 1564
-Sent Payload
-< 200
-< X-Brewery-Brand: Svijany
-Received Payload
+      All Messages
+      POST /messages{?id,token,username}
+      > X-Brewery-Since: 1564
+      Sent Payload
+      < 200
+      < X-Brewery-Brand: Svijany
+      Received Payload
     `;
 
     it('is identified as legacy Apiary Blueprint', () => {
@@ -145,16 +145,16 @@ Received Payload
   });
 
   describe('with \\r line breaks and arbitrary valid content', () => {
-    const source = `\r
---- API Name ---\r
-\r
-All Messages\r
-POST /messages{?id,token,username}\r
-> X-Brewery-Since: 1564\r
-Sent Payload\r
-< 200\r
-< X-Brewery-Brand: Svijany\r
-Received Payload\r
+    const source = dedent`\r
+      --- API Name ---\r
+      \r
+      All Messages\r
+      POST /messages{?id,token,username}\r
+      > X-Brewery-Since: 1564\r
+      Sent Payload\r
+      < 200\r
+      < X-Brewery-Brand: Svijany\r
+      Received Payload\r
     `;
 
     it('is identified as legacy Apiary Blueprint', () => {
@@ -166,22 +166,31 @@ Received Payload\r
     const source = 'HOST: http://example.com/api-path\n--- Sample API ---';
 
     it('is identified as legacy Apiary Blueprint', () => {
-      assert.equal(identify(source), 'text/vnd.legacyblueprint');
+      assert.equal(identify(source), 'application/swagger+json');
     });
   });
 });
 
 
 describe('Swagger', () => {
+
   describe('Swagger file with arbitrary valid JSON content', () => {
-    const source = `
-{
-  "swagger": "2.0",
-  "host": "example.com",
-  "basePath": "/api",
-  "schemes": ["http"],
-  "paths": {}
-}
+    const source = '{"swagger": "2.0", ..., "--- Ha ha ha ---"}';
+
+    it('is identified as Swagger', () => {
+      assert.equal(identify(source), 'application/swagger+json');
+    });
+  });
+
+  describe('Swagger file with arbitrary valid JSON content', () => {
+    const source = dedent`
+      {
+        "swagger": "2.0",
+        "host": "example.com",
+        "basePath": "/api",
+        "schemes": ["http"],
+        "paths": {}
+      }
     `;
 
     it('is identified as Swagger', () => {
@@ -190,14 +199,14 @@ describe('Swagger', () => {
   });
 
   describe('Swagger file with arbitrary valid YAML content', () => {
-    const source = `
----
-# comment
-swagger: "2.0"
-host: example.com
-basePath: /v1
-schemes:
-  - http
+    const source = dedent`
+      ---
+      # comment
+      swagger: "2.0"
+      host: example.com
+      basePath: /v1
+      schemes:
+        - http
     `;
 
     it('is identified as Swagger', () => {
@@ -205,18 +214,56 @@ schemes:
     });
   });
 
+  describe('YAML file with arbitrary valid content', () => {
+    const source = dedent`
+      --- !clarkevans.com/^invoice
+      invoice: 34843
+      date   : 2001-01-23
+      bill-to: &id001
+          given  : Chris
+          family : Dumars
+          address:
+              lines: |
+                  458 Walkman Dr.
+                  Suite #292
+              city    : Royal Oak
+              state   : MI
+              postal  : 48046
+      ship-to: *id001
+      product:
+          - sku         : BL394D
+            quantity    : 4
+            description : Basketball
+            price       : 450.00
+          - sku         : BL4438H
+            quantity    : 1
+            description : Super Hoop
+            price       : 2392.00
+      tax  : 251.42
+      total: 4443.52
+      comments: >
+          Late afternoon is best.
+          Backup contact is Nancy
+          Billsmer @ 338-4338.
+      `;
+
+    it('is not identified', () => {
+      assert.equal(identify(source), null);
+    });
+  });
+
   describe('GeoJSON file with arbitrary valid content', () => {
-    const source = `
-{
-  "type": "Feature",
-  "geometry": {
-    "type": "Point",
-    "coordinates": [125.6, 10.1]
-  },
-  "properties": {
-    "name": "Dinagat Islands"
-  }
-}
+    const source = dedent`
+      {
+        "type": "Feature",
+        "geometry": {
+          "type": "Point",
+          "coordinates": [125.6, 10.1]
+        },
+        "properties": {
+          "name": "Dinagat Islands"
+        }
+      }
     `;
 
     it('is not identified', () => {

--- a/test/identify-test.es6
+++ b/test/identify-test.es6
@@ -84,6 +84,14 @@ FORMAT: 1A\r
       assert.equal(identify(source), null);
     });
   });
+
+  describe('Plain text file with arbitrary content', () => {
+    const source = 'Beware! Beyond lies mortal danger for the likes of you!';
+
+    it('is not identified', () => {
+      assert.equal(identify(source), null);
+    });
+  });
 });
 
 
@@ -159,6 +167,60 @@ Received Payload\r
 
     it('is identified as legacy Apiary Blueprint', () => {
       assert.equal(identify(source), 'text/vnd.legacyblueprint');
+    });
+  });
+});
+
+
+describe('Swagger', () => {
+  describe('Swagger file with arbitrary valid JSON content', () => {
+    const source = `
+{
+  "swagger": "2.0",
+  "host": "example.com",
+  "basePath": "/api",
+  "schemes": ["http"],
+  "paths": {}
+}
+    `;
+
+    it('is identified as Swagger', () => {
+      assert.equal(identify(source), 'application/swagger+json');
+    });
+  });
+
+  describe('Swagger file with arbitrary valid YAML content', () => {
+    const source = `
+---
+# comment
+swagger: "2.0"
+host: example.com
+basePath: /v1
+schemes:
+  - http
+    `;
+
+    it('is identified as Swagger', () => {
+      assert.equal(identify(source), 'application/swagger+yaml');
+    });
+  });
+
+  describe('GeoJSON file with arbitrary valid content', () => {
+    const source = `
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [125.6, 10.1]
+  },
+  "properties": {
+    "name": "Dinagat Islands"
+  }
+}
+    `;
+
+    it('is not identified', () => {
+      assert.equal(identify(source), null);
     });
   });
 });

--- a/test/identify-test.es6
+++ b/test/identify-test.es6
@@ -125,18 +125,18 @@ describe('Legacy Apiary Blueprint', () => {
   });
 
   describe('with UTF8 BOM and arbitrary valid content', () => {
-    const source = `\uFEFF
-HOST: http://example.com/api-path
+    const source = dedent`\uFEFF
+      HOST: http://example.com/api-path
 
---- API Name ---
+      --- API Name ---
 
-All Messages
-POST /messages{?id,token,username}
-> X-Brewery-Since: 1564
-Sent Payload
-< 200
-< X-Brewery-Brand: Svijany
-Received Payload
+      All Messages
+      POST /messages{?id,token,username}
+      > X-Brewery-Since: 1564
+      Sent Payload
+      < 200
+      < X-Brewery-Brand: Svijany
+      Received Payload
     `;
 
     it('is identified as legacy Apiary Blueprint', () => {
@@ -145,7 +145,7 @@ Received Payload
   });
 
   describe('with \\r line breaks and arbitrary valid content', () => {
-    const source = dedent`\r
+    const source = `\r
       --- API Name ---\r
       \r
       All Messages\r
@@ -166,21 +166,13 @@ Received Payload
     const source = 'HOST: http://example.com/api-path\n--- Sample API ---';
 
     it('is identified as legacy Apiary Blueprint', () => {
-      assert.equal(identify(source), 'application/swagger+json');
+      assert.equal(identify(source), 'text/vnd.legacyblueprint');
     });
   });
 });
 
 
 describe('Swagger', () => {
-
-  describe('Swagger file with arbitrary valid JSON content', () => {
-    const source = '{"swagger": "2.0", ..., "--- Ha ha ha ---"}';
-
-    it('is identified as Swagger', () => {
-      assert.equal(identify(source), 'application/swagger+json');
-    });
-  });
 
   describe('Swagger file with arbitrary valid JSON content', () => {
     const source = dedent`
@@ -270,4 +262,18 @@ describe('Swagger', () => {
       assert.equal(identify(source), null);
     });
   });
+
+  describe('Something that is Swagger but contains Blueprint stuff', () => {
+    const sources = [
+      '{"swagger": "2.0", "content": "--- Ha ha ha ---"}',
+      '{"swagger": "2.0", "content": "+ Response 200"}'
+    ];
+
+    it('is identified as Swagger', () => {
+      sources.forEach((source) => {
+        assert.equal(identify(source), 'application/swagger+json');
+      });
+
+    });
+  })
 });


### PR DESCRIPTION
I spent some of my free time to hack this, but it seems to be more complicated then I originally thought as Swagger has two representations - JSON and YAML. Issues:

- no support for recognizing YAML so far
- if JSON/YAML parsers are involved, Deckard Cain could block the Node.js event loop in case the file is huge