### PR TITLE
Fixing what is in the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+.DS_Store
+*.sublime-*
+test
+karma.conf.js


### PR DESCRIPTION
In case `.npmignore` is not present, `npm` takes contents of `.gitignore` as a list of files to ignore for the resulting package. Because of this, `lib` was ignored in all previous releases and thus the code could not be used by anyone, actually. (*facepalm*)