### PR TITLE
JSON fix for multiple spaces before and after colon between key and value

### DIFF
--- a/src/deckardcain.js
+++ b/src/deckardcain.js
@@ -3,12 +3,12 @@ export const API_BLUEPRINT_RESPONSE = /\+\s+(?:response|request)\s+\d{3}/i;
 
 export const LEGACY_BLUEPRINT_TITLE = /[-]{3}(?=( [^\n\r]+ | )[-]{3}([\n\r]{1,2}|[.]{0}))/i;
 
-export const SWAGGER_JSON = /^[\uFEFF]?{[\s\S]*["']swagger["']: ?["']\d\.\d["'],?/i;
+export const SWAGGER_JSON = /^[\uFEFF]?{[\s\S]*["']swagger["']\s*:\s*["']\d\.\d["'],?/i;
 export const SWAGGER_YAML = /(?:^|\n)\s*swagger: ["']\d\.\d["']\n/i;
 
-export const REFRACT_API_DESCRIPTION_ELEMENT_JSON = /[\uFEFF]?\n?\s*["']element["']: ?["']category["']/i;
-export const REFRACT_API_DESCRIPTION_CLASS_JSON = /"meta"\s*:\s*\{\s*"classes"\:\s*\[\s*"api"\s*\]/i;
-export const REFRACT_PARSE_RESULT_ELEMENT_JSON = /[\uFEFF]?\n?\s*["']element["']: ?["']parseResult["']/i;
+export const REFRACT_API_DESCRIPTION_ELEMENT_JSON = /[\uFEFF]?\n?\s*["']element["']\s*:\s*["']category["']/i;
+export const REFRACT_API_DESCRIPTION_CLASS_JSON = /"meta"\s*:\s*\{\s*"classes"\s*:\s*\[\s*"api"\s*\]/i;
+export const REFRACT_PARSE_RESULT_ELEMENT_JSON = /[\uFEFF]?\n?\s*["']element["']\s*:\s*["']parseResult["']/i;
 
 export const REFRACT_API_DESCRIPTION_ELEMENT_YAML = /[\uFEFF]?\n?\s*element: ?["']category["']/i;
 export const REFRACT_API_DESCRIPTION_CLASS_YAML = /\s*meta:\s+classes:\s+\-\s["']api["']/i;

--- a/test/identify-test.js
+++ b/test/identify-test.js
@@ -248,6 +248,22 @@ describe('Swagger', function() {
     });
   });
 
+  describe('Swagger file with arbitrary valid JSON content and multiple spaces between "swagger" key, colon and value', function() {
+    const source = dedent`
+      {
+        "swagger"  :  "2.0",
+        "host": "example.com",
+        "basePath": "/api",
+        "schemes": ["http"],
+        "paths": {}
+      }
+    `;
+
+    it('is identified as Swagger', function() {
+      assert.equal(identify(source), 'application/swagger+json');
+    });
+  });
+
   describe('Swagger file with arbitrary valid JSON content, but swagger key isn\'t first', function() {
     const source = dedent`
       {
@@ -390,6 +406,16 @@ describe('Refract API Description namespace', function() {
         "element": "category"
       }`,
       '{"element":"category","meta":{"classes":["api"]}}',
+      dedent`
+      {
+        "meta": {
+          "classes" : [
+            "api"
+          ]
+        },
+        "element"  : "category"
+      }`,
+      '{"element" :"category","meta":{"classes" :  ["api"]}}',
     ];
 
     it('is identified as Refract in JSON format', function() {
@@ -402,6 +428,7 @@ describe('Refract API Description namespace', function() {
   describe('JSON file with parseResult namespace', function() {
     const sources = [
       '{"element":"parseResult","meta":{},"attributes":{},"content":[{"element":"category","meta":{"classes":["api"],"title":"DescriptionExample"}}]}',
+      '{"element"  : "parseResult","meta":{},"attributes":{},"content":[{"element":"category","meta":{"classes":["api"],"title":"DescriptionExample"}}]}',
     ];
 
     it('isn\'t identified as Refract', function() {


### PR DESCRIPTION
automatically generated swagger JSON from OIC have space before colon after 'swagger' keyword. And when user pasting it to Apiary, it will not be detected as swagger and parsed.
AFAIK whitespaces are valid between key and value around colon in JSON format.